### PR TITLE
SB3-3167: remove unneeded references to font awesome

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=ReplaceMe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1353,11 +1353,6 @@
         }
       }
     },
-    "@fortawesome/fontawesome-pro": {
-      "version": "5.15.4",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/5.15.4/fontawesome-pro-5.15.4.tgz",
-      "integrity": "sha512-ApOqpDdKgA79xfLZH3B5PucZxj+TZyQUSrZ4bKkbJCR+zjmveQ4/gp/uXc5bNNhsdtJUy16BYJ/lAVydca2Y5Q=="
-    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -6822,11 +6817,6 @@
           }
         }
       }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,13 +11,11 @@
     "url": "https://github.com/springbot/grapesjs"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-pro": "^5.15.4",
     "backbone": "1.3.3",
     "backbone-undo": "^0.2.5",
     "cash-dom": "^1.3.7",
     "codemirror": "^5.42.0",
     "codemirror-formatting": "^1.0.0",
-    "font-awesome": "^4.7.0",
     "keymaster": "^1.6.2",
     "promise-polyfill": "^8.1.0",
     "spectrum-colorpicker": "^1.8.0",


### PR DESCRIPTION
FA is now self-hosted, so it doesn't need to be in the package manager